### PR TITLE
feat: Add multiple embedders and expand test snippets for comparison

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,21 +1,46 @@
 from sentence_transformers import SentenceTransformer
 
-# Download from the 🤗 Hub
-model = SentenceTransformer("Qodo/Qodo-Embed-1-1.5B")
-# Run inference
+# Define the list of model names
+model_names = [
+    "Qodo/Qodo-Embed-1-1.5B",
+    "sentence-transformers/all-MiniLM-L6-v2",
+    "sentence-transformers/all-mpnet-base-v2"
+]
+
+# The sentences to encode
 sentences = [
     'accumulator = sum(item.value for item in collection)',  
     'result = reduce(lambda acc, curr: acc + curr.amount, data, 0)',  
     'matrix = [[i*j for j in range(n)] for i in range(n)]'  ,
     'a = sum(items)',
     'def add(list): s=0; for i in list: s+=i;  return s',
+    # New snippets:
+    'squares_of_evens = [x*x for x in range(10) if x % 2 == 0]',
+    'class Greeter:\\n def __init__(self, name):\\n  self.name = name\\n def greet(self):\\n  return f"Hello, {self.name}!"',
+    'def factorial(n):\\n if n == 0:\\n  return 1\\n else:\\n  return n * factorial(n-1)',
+    'reversed_string = "hello"[::-1]',
+    'my_dict = {"a": 1, "b": 2}; my_dict["c"] = 3',
+    '# This is a comment\\nx = 10 + 5',
+    'def find_max(numbers):\\n max_val = numbers[0]\\n for x in numbers:\\n  if x > max_val:\\n   max_val = x\\n return max_val'
 ]
-embeddings = model.encode(sentences)
-print(embeddings)
-# [3, 1536]
 
-# Get the similarity scores for the embeddings
-similarities = model.similarity(embeddings, embeddings)
-print(similarities)
+# Loop through each model
+for model_name in model_names:
+    print(f"\n---- Running Model: {model_name} ----")
 
-# [3, 3]
+    # Instantiate the SentenceTransformer with the current model name
+    # Download from the 🤗 Hub
+    model = SentenceTransformer(model_name)
+    
+    # Run inference
+    # Encode the sentences
+    embeddings = model.encode(sentences)
+    print("Embeddings:")
+    print(embeddings)
+    # [3, 1536] # This comment might need adjustment or removal depending on actual output dimensions
+
+    # Get the similarity scores for the embeddings
+    similarities = model.similarity(embeddings, embeddings)
+    print("Similarity Matrix:")
+    print(similarities)
+    # [3, 3] # This comment might need adjustment or removal


### PR DESCRIPTION
This commit introduces the following changes:

1.  **Added new Hugging Face embedders:**
    *   `sentence-transformers/all-MiniLM-L6-v2`
    *   `sentence-transformers/all-mpnet-base-v2`
    These are included alongside the existing `Qodo/Qodo-Embed-1-1.5B` model.

2.  **Modified `example.py` for comparison:**
    *   The script now iterates through the list of specified embedders.
    *   For each embedder, it prints the model name, generates embeddings for the test snippets, and prints the resulting similarity matrix. This allows for a direct comparison of their outputs.

3.  **Expanded test snippets:**
    *   The list of code snippets in `example.py` has been significantly expanded with more diverse examples, including:
        - List comprehensions with conditionals
        - Simple class definitions
        - Recursive functions
        - String manipulations
        - Dictionary operations
        - Code with comments
        - Slightly longer, more realistic functions
    This provides a more comprehensive basis for evaluating the embedders' performance on various code structures.

No changes to `requirements.txt` were necessary as the new models are compatible with the existing `sentence-transformers` library.